### PR TITLE
Upgrade @primer/octicons to v14.2

### DIFF
--- a/ICON_INDEX.md
+++ b/ICON_INDEX.md
@@ -1,6 +1,6 @@
 # Icon Index
 
-> 447 icons from svelte-octicons@14.1.0.
+> 452 icons from svelte-octicons@14.1.0.
 
 ## Usage
 
@@ -247,6 +247,7 @@
 - KebabHorizontal24
 - Key16
 - Key24
+- KeyAsterisk16
 - Law16
 - Law24
 - LightBulb16
@@ -387,6 +388,10 @@
 - Skip24
 - Smiley16
 - Smiley24
+- SortAsc16
+- SortAsc24
+- SortDesc16
+- SortDesc24
 - Square16
 - Square24
 - SquareFill16

--- a/package.json
+++ b/package.json
@@ -16,9 +16,9 @@
     "test": "svelte-check --workspace=test"
   },
   "devDependencies": {
-    "@primer/octicons": "14.1.0",
+    "@primer/octicons": "14.2.0",
     "svelte": "^3.38.2",
-    "svelte-check": "^1.5.4",
+    "svelte-check": "^1.6.0",
     "svelte-readme": "^3.1.0"
   },
   "repository": {

--- a/test/Octicons.test.svelte
+++ b/test/Octicons.test.svelte
@@ -1,5 +1,11 @@
 <script lang="ts">
-  import { Alert16, Rows16, Rocket16, Duplicate16 } from "../types";
+  import {
+    Alert16,
+    Rows16,
+    Rocket16,
+    Duplicate16,
+    KeyAsterisk16,
+  } from "../types";
   import Version24 from "../types/Verified24";
   import GitPullRequestClosed16 from "../types/GitPullRequestClosed16";
   import * as Octicons from "../types";
@@ -11,6 +17,7 @@
 <Version24 />
 <Duplicate16 />
 <GitPullRequestClosed16 height="20" />
+<KeyAsterisk16 />
 
 {#each Object.keys(Octicons) as octicon}
   <div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -23,10 +23,10 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
-"@primer/octicons@14.1.0":
-  version "14.1.0"
-  resolved "https://registry.yarnpkg.com/@primer/octicons/-/octicons-14.1.0.tgz#8108f2328e8fcaf1f652a5724608d9343dccefa2"
-  integrity sha512-I/gRlM2meKPKXFN/1fxLoigPXvAUsivxRCih7vgeO7o4qrNNsl6Ah85l3UBbFi0t7ttjMde2+bS1A32a1Hu0BA==
+"@primer/octicons@14.2.0":
+  version "14.2.0"
+  resolved "https://registry.yarnpkg.com/@primer/octicons/-/octicons-14.2.0.tgz#3597439b86e8dec94bdaa81e05cc0fec0afe00aa"
+  integrity sha512-xeosxkcz29Ywmn0rI+FxOJCuRkwRrxEz32WGLOmCEdx0tbMsTa3M3JQ9x4x45ByWvfRzWquAp426iV3S09MX9A==
   dependencies:
     object-assign "^4.1.1"
 
@@ -527,6 +527,11 @@ minimist@^1.2.5:
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
   integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
 
+mri@^1.1.0:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/mri/-/mri-1.1.6.tgz#49952e1044db21dbf90f6cd92bc9c9a777d415a6"
+  integrity sha512-oi1b3MfbyGa7FJMP9GmLTttni5JoICpYBRlq+x5V16fZbLsnL9N3wFqqIm/nIG43FjUFkFh9Epzp/kzUGUnJxQ==
+
 no-case@^2.2.0:
   version "2.3.2"
   resolved "https://registry.npmjs.org/no-case/-/no-case-2.3.2.tgz#60b813396be39b3f1288a4c1ed5d1e7d28b464ac"
@@ -671,6 +676,13 @@ rollup@^2.36.2:
   optionalDependencies:
     fsevents "~2.3.1"
 
+sade@^1.7.4:
+  version "1.7.4"
+  resolved "https://registry.yarnpkg.com/sade/-/sade-1.7.4.tgz#ea681e0c65d248d2095c90578c03ca0bb1b54691"
+  integrity sha512-y5yauMD93rX840MwUJr7C1ysLFBgMspsdTo4UVrDg3fXDvtwOyIqykhVAAm6fk/3au77773itJStObgK+LKaiA==
+  dependencies:
+    mri "^1.1.0"
+
 safe-buffer@^5.1.0:
   version "5.2.1"
   resolved "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
@@ -727,16 +739,17 @@ supports-color@^7.0.0, supports-color@^7.1.0:
   dependencies:
     has-flag "^4.0.0"
 
-svelte-check@^1.5.4:
-  version "1.5.4"
-  resolved "https://registry.yarnpkg.com/svelte-check/-/svelte-check-1.5.4.tgz#9e37a36c30dbf75caa729f507e925424c67a237b"
-  integrity sha512-0rnBT2uqgYQeVsLJYZqAjkZn0k2TiphbOv7p602QmRMPT5VqFrkAaomZm5l4K3coxGSJlC0tDEVCKCQJ6i2jqw==
+svelte-check@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/svelte-check/-/svelte-check-1.6.0.tgz#fcc7b28252a89be0e4cd369c58bbf8e76e81295f"
+  integrity sha512-nQTlbFJWhwoeLY5rkhgbjzGQSwk5F1pRdEXait0EFaQSrE/iJF+PIjrQlk0BjL/ogk9HaR9ZI0DQSYrl7jl3IQ==
   dependencies:
     chalk "^4.0.0"
     chokidar "^3.4.1"
     glob "^7.1.6"
     import-fresh "^3.2.1"
     minimist "^1.2.5"
+    sade "^1.7.4"
     source-map "^0.7.3"
     svelte-preprocess "^4.0.0"
     typescript "*"


### PR DESCRIPTION
**Features**

- Upgrade `@primer/octicons` to version 14.2.0 (net +5 icons)