### PR TITLE
feat(deps): upgrade `@primer/octicons` to 17.6.0

### DIFF
--- a/ICON_INDEX.md
+++ b/ICON_INDEX.md
@@ -1,6 +1,6 @@
 # Icon Index
 
-> 516 total icons
+> 521 total icons
 
 ## Icons
 
@@ -9,6 +9,8 @@
 - Alert16
 - Alert24
 - AlertFill12
+- AlertFill16
+- AlertFill24
 - Apps16
 - Archive16
 - Archive24
@@ -70,10 +72,12 @@
 - Checkbox24
 - Checklist16
 - Checklist24
+- ChevronDown12
 - ChevronDown16
 - ChevronDown24
 - ChevronLeft16
 - ChevronLeft24
+- ChevronRight12
 - ChevronRight16
 - ChevronRight24
 - ChevronUp16
@@ -295,6 +299,7 @@
 - Lock16
 - Lock24
 - Log16
+- Log24
 - LogoGist16
 - LogoGithub16
 - Mail16

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "prepack": "node build"
   },
   "devDependencies": {
-    "@primer/octicons": "17.5.0",
+    "@primer/octicons": "17.6.0",
     "gh-pages": "^4.0.0",
     "svelte": "^3.49.0",
     "svelte-readme": "^3.6.3",

--- a/test/Octicons.test.svelte
+++ b/test/Octicons.test.svelte
@@ -16,6 +16,7 @@
     Copilot16,
     Cache16,
     ShieldSlash16,
+    AlertFill16
   } from "../lib";
   import Version24 from "../lib/Verified24.svelte";
   import GitPullRequestClosed16 from "../lib/GitPullRequestClosed16.svelte";
@@ -42,6 +43,7 @@
 <Copilot16 />
 <Cache16 />
 <ShieldSlash16 />
+<AlertFill16 />
 
 {#each Object.keys(Octicons) as octicon}
   <div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -63,10 +63,10 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
-"@primer/octicons@17.5.0":
-  version "17.5.0"
-  resolved "https://registry.yarnpkg.com/@primer/octicons/-/octicons-17.5.0.tgz#a89a658c54524adb0b0eae95b0eb5a98a904097b"
-  integrity sha512-Bx/IfCMXZSq0YBPspoRoALVou5LiAdSg4yNtwEoYDZ137aq238Glnb6SBE5BtRSyzegTv7wFp/uYUPXMXT2MRg==
+"@primer/octicons@17.6.0":
+  version "17.6.0"
+  resolved "https://registry.yarnpkg.com/@primer/octicons/-/octicons-17.6.0.tgz#aa970dad4cd9c4140a0980970b6bb3661d95b3e2"
+  integrity sha512-aLXU7zwl6Z5BBL93RiQX//D6isO9avU4SwEt6qsTm5mo6CiKUDBEwwz9tUlYJcRTWbZKsyt4Lpg/oUT+tqbxuQ==
   dependencies:
     object-assign "^4.1.1"
 


### PR DESCRIPTION
- upgrade `@primer/octicons` to [v17.6.0](https://github.com/primer/octicons/releases/tag/v17.6.0) (net +5 icons)