### PR TITLE
feat(deps): upgrade `@primer/octicons` to 17.8.0

### DIFF
--- a/ICON_INDEX.md
+++ b/ICON_INDEX.md
@@ -1,6 +1,6 @@
 # Icon Index
 
-> 521 total icons
+> 529 total icons
 
 ## Icons
 
@@ -18,7 +18,9 @@
 - ArrowBoth24
 - ArrowDown16
 - ArrowDown24
+- ArrowDownLeft16
 - ArrowDownLeft24
+- ArrowDownRight16
 - ArrowDownRight24
 - ArrowLeft16
 - ArrowLeft24
@@ -28,7 +30,9 @@
 - ArrowSwitch24
 - ArrowUp16
 - ArrowUp24
+- ArrowUpLeft16
 - ArrowUpLeft24
+- ArrowUpRight16
 - ArrowUpRight24
 - Beaker16
 - Beaker24
@@ -273,6 +277,10 @@
 - IssueOpened24
 - IssueReopened16
 - IssueReopened24
+- IssueTrackedBy16
+- IssueTrackedBy24
+- IssueTrackedIn16
+- IssueTrackedIn24
 - Italic16
 - Italic24
 - Iterations16

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "prepack": "node build"
   },
   "devDependencies": {
-    "@primer/octicons": "17.6.0",
+    "@primer/octicons": "17.8.0",
     "gh-pages": "^4.0.0",
     "svelte": "^3.52.0",
     "svelte-readme": "^3.6.3",

--- a/test/Octicons.test.svelte
+++ b/test/Octicons.test.svelte
@@ -16,7 +16,8 @@
     Copilot16,
     Cache16,
     ShieldSlash16,
-    AlertFill16
+    AlertFill16,
+    ArrowDownLeft16,
   } from "../lib";
   import Version24 from "../lib/Verified24.svelte";
   import GitPullRequestClosed16 from "../lib/GitPullRequestClosed16.svelte";
@@ -44,6 +45,7 @@
 <Cache16 />
 <ShieldSlash16 />
 <AlertFill16 />
+<ArrowDownLeft16 />
 
 {#each Object.keys(Octicons) as octicon}
   <div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -63,10 +63,10 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
-"@primer/octicons@17.6.0":
-  version "17.6.0"
-  resolved "https://registry.yarnpkg.com/@primer/octicons/-/octicons-17.6.0.tgz#aa970dad4cd9c4140a0980970b6bb3661d95b3e2"
-  integrity sha512-aLXU7zwl6Z5BBL93RiQX//D6isO9avU4SwEt6qsTm5mo6CiKUDBEwwz9tUlYJcRTWbZKsyt4Lpg/oUT+tqbxuQ==
+"@primer/octicons@17.8.0":
+  version "17.8.0"
+  resolved "https://registry.yarnpkg.com/@primer/octicons/-/octicons-17.8.0.tgz#58591c1cacc018cd0dd4628cccb0ed942ecb9b8a"
+  integrity sha512-2OyvErMeqsJ/K1ZbQ902QowrwqXq+BMmGiL+PGqFzUQ85wmaWj+CobOwWPxBLs/xVGzacJJPt4fWcx4EMoRMkg==
   dependencies:
     object-assign "^4.1.1"
 


### PR DESCRIPTION
- upgrade `@primer/octicons` to [v17.8.0](https://github.com/primer/octicons/releases/tag/v17.8.0) (net +8 icons)