### PR TITLE
feat(deps): upgrade `@primer/octicons` to 17.9.0

### DIFF
--- a/ICON_INDEX.md
+++ b/ICON_INDEX.md
@@ -1,6 +1,6 @@
 # Icon Index
 
-> 529 total icons
+> 537 total icons
 
 ## Icons
 
@@ -92,6 +92,8 @@
 - CircleSlash24
 - Clock16
 - Clock24
+- ClockFill16
+- ClockFill24
 - Cloud16
 - Cloud24
 - CloudOffline16
@@ -377,6 +379,10 @@
 - PlusCircle24
 - Project16
 - Project24
+- ProjectRoadmap16
+- ProjectRoadmap24
+- ProjectSymlink16
+- ProjectSymlink24
 - Pulse16
 - Pulse24
 - Question16
@@ -441,6 +447,8 @@
 - SingleSelect24
 - Skip16
 - Skip24
+- SkipFill16
+- SkipFill24
 - Sliders16
 - Smiley16
 - Smiley24

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "prepack": "node build"
   },
   "devDependencies": {
-    "@primer/octicons": "17.8.0",
+    "@primer/octicons": "17.9.0",
     "gh-pages": "^4.0.0",
     "svelte": "^3.52.0",
     "svelte-readme": "^3.6.3",

--- a/test/Octicons.test.svelte
+++ b/test/Octicons.test.svelte
@@ -18,6 +18,7 @@
     ShieldSlash16,
     AlertFill16,
     ArrowDownLeft16,
+    ClockFill16,
   } from "../lib";
   import Version24 from "../lib/Verified24.svelte";
   import GitPullRequestClosed16 from "../lib/GitPullRequestClosed16.svelte";
@@ -46,6 +47,7 @@
 <ShieldSlash16 />
 <AlertFill16 />
 <ArrowDownLeft16 />
+<ClockFill16 />
 
 {#each Object.keys(Octicons) as octicon}
   <div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -63,10 +63,10 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
-"@primer/octicons@17.8.0":
-  version "17.8.0"
-  resolved "https://registry.yarnpkg.com/@primer/octicons/-/octicons-17.8.0.tgz#58591c1cacc018cd0dd4628cccb0ed942ecb9b8a"
-  integrity sha512-2OyvErMeqsJ/K1ZbQ902QowrwqXq+BMmGiL+PGqFzUQ85wmaWj+CobOwWPxBLs/xVGzacJJPt4fWcx4EMoRMkg==
+"@primer/octicons@17.9.0":
+  version "17.9.0"
+  resolved "https://registry.yarnpkg.com/@primer/octicons/-/octicons-17.9.0.tgz#bfa05140752815210b594f50222f1e7abb578523"
+  integrity sha512-B6y3VxPrF6U+GUjZR883NsstI7v/Qcup9puDG+fOJvCm8b7UXNl46TbRrctMCZnYlyIzUF3/SgjJhr5od/Y6sw==
   dependencies:
     object-assign "^4.1.1"
 


### PR DESCRIPTION
- upgrade `@primer/octicons` to [v17.9.0](https://github.com/primer/octicons/releases/tag/v17.9.0) (net +8 icons)