### PR TITLE
feat(deps): upgrade `@primer/octicons` to 17.10.0

### DIFF
--- a/ICON_INDEX.md
+++ b/ICON_INDEX.md
@@ -1,6 +1,6 @@
 # Icon Index
 
-> 537 total icons
+> 549 total icons
 
 ## Icons
 
@@ -239,6 +239,8 @@
 - GitPullRequestDraft24
 - Globe16
 - Globe24
+- Goal16
+- Goal24
 - Grabber16
 - Grabber24
 - Graph16
@@ -389,6 +391,10 @@
 - Question24
 - Quote16
 - Quote24
+- Read16
+- Read24
+- RelFilePath16
+- RelFilePath24
 - Reply16
 - Reply24
 - Repo16
@@ -456,6 +462,8 @@
 - SortAsc24
 - SortDesc16
 - SortDesc24
+- SponsorTiers16
+- SponsorTiers24
 - Square16
 - Square24
 - SquareFill16
@@ -515,10 +523,14 @@
 - Typography24
 - Unfold16
 - Unfold24
+- Unlink16
+- Unlink24
 - Unlock16
 - Unlock24
 - Unmute16
 - Unmute24
+- Unread16
+- Unread24
 - Unverified16
 - Unverified24
 - Upload16

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "prepack": "node build"
   },
   "devDependencies": {
-    "@primer/octicons": "17.9.0",
+    "@primer/octicons": "17.10.0",
     "gh-pages": "^4.0.0",
     "svelte": "^3.52.0",
     "svelte-readme": "^3.6.3",

--- a/test/Octicons.test.svelte
+++ b/test/Octicons.test.svelte
@@ -19,6 +19,7 @@
     AlertFill16,
     ArrowDownLeft16,
     ClockFill16,
+    Goal16,
   } from "../lib";
   import Version24 from "../lib/Verified24.svelte";
   import GitPullRequestClosed16 from "../lib/GitPullRequestClosed16.svelte";
@@ -48,6 +49,7 @@
 <AlertFill16 />
 <ArrowDownLeft16 />
 <ClockFill16 />
+<Goal16 />
 
 {#each Object.keys(Octicons) as octicon}
   <div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -63,10 +63,10 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
-"@primer/octicons@17.9.0":
-  version "17.9.0"
-  resolved "https://registry.yarnpkg.com/@primer/octicons/-/octicons-17.9.0.tgz#bfa05140752815210b594f50222f1e7abb578523"
-  integrity sha512-B6y3VxPrF6U+GUjZR883NsstI7v/Qcup9puDG+fOJvCm8b7UXNl46TbRrctMCZnYlyIzUF3/SgjJhr5od/Y6sw==
+"@primer/octicons@17.10.0":
+  version "17.10.0"
+  resolved "https://registry.yarnpkg.com/@primer/octicons/-/octicons-17.10.0.tgz#8a29c42c3d63a3781e08eaac81ba0f9a5290d86e"
+  integrity sha512-rg+NfA4M/SFutVzsqGwGWoKgXpHpTAbnoGvyGbkswT7iLV0PBFGJRkV61MhC61wEEF4SErMiaH5tOQKlvgvV9A==
   dependencies:
     object-assign "^4.1.1"
 


### PR DESCRIPTION
- upgrade `@primer/octicons` to [v17.10.0](https://github.com/primer/octicons/releases/tag/v17.10.0) (net +12 icons)