### PR TITLE
feat(deps): upgrade `@primer/octicons` to 17.11.0

### DIFF
--- a/ICON_INDEX.md
+++ b/ICON_INDEX.md
@@ -1,6 +1,6 @@
 # Icon Index
 
-> 549 total icons
+> 552 total icons
 
 ## Icons
 
@@ -84,6 +84,7 @@
 - ChevronRight12
 - ChevronRight16
 - ChevronRight24
+- ChevronUp12
 - ChevronUp16
 - ChevronUp24
 - Circle16
@@ -210,6 +211,7 @@
 - FileZip24
 - Filter16
 - Filter24
+- FiscalHost16
 - Flame16
 - Flame24
 - Fold16
@@ -462,6 +464,7 @@
 - SortAsc24
 - SortDesc16
 - SortDesc24
+- SparkleFill16
 - SponsorTiers16
 - SponsorTiers24
 - Square16

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "prepack": "node build"
   },
   "devDependencies": {
-    "@primer/octicons": "17.10.0",
+    "@primer/octicons": "17.11.0",
     "gh-pages": "^4.0.0",
     "svelte": "^3.52.0",
     "svelte-readme": "^3.6.3",

--- a/test/Octicons.test.svelte
+++ b/test/Octicons.test.svelte
@@ -20,6 +20,7 @@
     ArrowDownLeft16,
     ClockFill16,
     Goal16,
+    SparkleFill16,
   } from "../lib";
   import Version24 from "../lib/Verified24.svelte";
   import GitPullRequestClosed16 from "../lib/GitPullRequestClosed16.svelte";
@@ -50,6 +51,7 @@
 <ArrowDownLeft16 />
 <ClockFill16 />
 <Goal16 />
+<SparkleFill16 />
 
 {#each Object.keys(Octicons) as octicon}
   <div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -63,10 +63,10 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
-"@primer/octicons@17.10.0":
-  version "17.10.0"
-  resolved "https://registry.yarnpkg.com/@primer/octicons/-/octicons-17.10.0.tgz#8a29c42c3d63a3781e08eaac81ba0f9a5290d86e"
-  integrity sha512-rg+NfA4M/SFutVzsqGwGWoKgXpHpTAbnoGvyGbkswT7iLV0PBFGJRkV61MhC61wEEF4SErMiaH5tOQKlvgvV9A==
+"@primer/octicons@17.11.0":
+  version "17.11.0"
+  resolved "https://registry.yarnpkg.com/@primer/octicons/-/octicons-17.11.0.tgz#ac941cbb1ea1095c629a3e8c24116e7ea4424a5f"
+  integrity sha512-9+u/o1sat1BzKOa8xxyUFO3dZmpj19mAtMTkHBUMqps6YVtnKOfjsAbMZm4XpTTTa+2m/E7fmD4+KDsw9lf/DA==
   dependencies:
     object-assign "^4.1.1"
 


### PR DESCRIPTION
- upgrade `@primer/octicons` to [v17.11.0](https://github.com/primer/octicons/releases/tag/v17.11.0) (net +3 icons)