### PR TITLE
feat(deps): upgrade `@primer/octicons` to 17.12.0

### DIFF
--- a/ICON_INDEX.md
+++ b/ICON_INDEX.md
@@ -1,6 +1,6 @@
 # Icon Index
 
-> 552 total icons
+> 565 total icons
 
 ## Icons
 
@@ -233,6 +233,7 @@
 - GitMerge16
 - GitMerge24
 - GitMergeQueue16
+- GitMergeQueue24
 - GitPullRequest16
 - GitPullRequest24
 - GitPullRequestClosed16
@@ -333,6 +334,14 @@
 - Moon24
 - MortarBoard16
 - MortarBoard24
+- MoveToBottom16
+- MoveToBottom24
+- MoveToEnd16
+- MoveToEnd24
+- MoveToStart16
+- MoveToStart24
+- MoveToTop16
+- MoveToTop24
 - MultiSelect16
 - MultiSelect24
 - Mute16
@@ -556,3 +565,7 @@
 - XCircleFill24
 - Zap16
 - Zap24
+- ZoomIn16
+- ZoomIn24
+- ZoomOut16
+- ZoomOut24

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "prepack": "node build"
   },
   "devDependencies": {
-    "@primer/octicons": "17.11.0",
+    "@primer/octicons": "17.12.0",
     "gh-pages": "^4.0.0",
     "svelte": "^3.52.0",
     "svelte-readme": "^3.6.3",

--- a/test/Octicons.test.svelte
+++ b/test/Octicons.test.svelte
@@ -21,6 +21,7 @@
     ClockFill16,
     Goal16,
     SparkleFill16,
+    GitMergeQueue24,
   } from "../lib";
   import Version24 from "../lib/Verified24.svelte";
   import GitPullRequestClosed16 from "../lib/GitPullRequestClosed16.svelte";
@@ -52,6 +53,7 @@
 <ClockFill16 />
 <Goal16 />
 <SparkleFill16 />
+<GitMergeQueue24 />
 
 {#each Object.keys(Octicons) as octicon}
   <div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -63,10 +63,10 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
-"@primer/octicons@17.11.0":
-  version "17.11.0"
-  resolved "https://registry.yarnpkg.com/@primer/octicons/-/octicons-17.11.0.tgz#ac941cbb1ea1095c629a3e8c24116e7ea4424a5f"
-  integrity sha512-9+u/o1sat1BzKOa8xxyUFO3dZmpj19mAtMTkHBUMqps6YVtnKOfjsAbMZm4XpTTTa+2m/E7fmD4+KDsw9lf/DA==
+"@primer/octicons@17.12.0":
+  version "17.12.0"
+  resolved "https://registry.yarnpkg.com/@primer/octicons/-/octicons-17.12.0.tgz#4d4650b193d516edc2155e1c52ffe8c347cc4a78"
+  integrity sha512-r13VTHQ7kZmqKtMQa8lfdpr0ocqdMOYGiDWuUrIeBCq+V87u6oasbuRxy5A3y8oLxW0QXmnISr9DPT5ybAoadA==
   dependencies:
     object-assign "^4.1.1"
 


### PR DESCRIPTION
- upgrade `@primer/octicons` to [v17.12.0](https://github.com/primer/octicons/releases/tag/v17.12.0) (net +13 icons)