### PR TITLE
feat(deps): upgrade `@primer/octicons` to 18.0.0

### DIFF
--- a/ICON_INDEX.md
+++ b/ICON_INDEX.md
@@ -1,6 +1,6 @@
 # Icon Index
 
-> 565 total icons
+> 566 total icons
 
 ## Icons
 
@@ -286,8 +286,8 @@
 - IssueReopened24
 - IssueTrackedBy16
 - IssueTrackedBy24
-- IssueTrackedIn16
-- IssueTrackedIn24
+- IssueTracks16
+- IssueTracks24
 - Italic16
 - Italic24
 - Iterations16
@@ -450,6 +450,7 @@
 - ShieldLock16
 - ShieldLock24
 - ShieldSlash16
+- ShieldSlash24
 - ShieldX16
 - ShieldX24
 - SidebarCollapse16

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "prepack": "node build"
   },
   "devDependencies": {
-    "@primer/octicons": "17.12.0",
+    "@primer/octicons": "18.0.0",
     "gh-pages": "^4.0.0",
     "svelte": "^3.52.0",
     "svelte-readme": "^3.6.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -63,10 +63,10 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
-"@primer/octicons@17.12.0":
-  version "17.12.0"
-  resolved "https://registry.yarnpkg.com/@primer/octicons/-/octicons-17.12.0.tgz#4d4650b193d516edc2155e1c52ffe8c347cc4a78"
-  integrity sha512-r13VTHQ7kZmqKtMQa8lfdpr0ocqdMOYGiDWuUrIeBCq+V87u6oasbuRxy5A3y8oLxW0QXmnISr9DPT5ybAoadA==
+"@primer/octicons@18.0.0":
+  version "18.0.0"
+  resolved "https://registry.yarnpkg.com/@primer/octicons/-/octicons-18.0.0.tgz#529426573c921a2f347af4076032f61cb81c6f08"
+  integrity sha512-EC2T95Xl9FCt84pVROjGmwfBvDWxnvWxL+RGsWYNxr1qY7UO58WgLScgi7K8p4gSK5V/k9vHi/k1EhunIyRGRw==
   dependencies:
     object-assign "^4.1.1"
 


### PR DESCRIPTION
- upgrade `@primer/octicons` to [v18.0.0](https://github.com/primer/octicons/releases/tag/v18.0.0) (net +1 icon)

**Breaking Changes**

- `IssueTrackedIn16` -> `IssueTracks16`
- `IssueTrackedIn24` -> `IssueTracks24`