### PR TITLE
feat(deps): upgrade `@primer/octicons` to 18.2.0

### DIFF
--- a/ICON_INDEX.md
+++ b/ICON_INDEX.md
@@ -1,6 +1,6 @@
 # Icon Index
 
-> 566 total icons
+> 574 total icons
 
 ## Icons
 
@@ -162,6 +162,12 @@
 - DiffModified16
 - DiffRemoved16
 - DiffRenamed16
+- DiscussionClosed16
+- DiscussionClosed24
+- DiscussionDuplicate16
+- DiscussionDuplicate24
+- DiscussionOutdated16
+- DiscussionOutdated24
 - Dot16
 - Dot24
 - DotFill16
@@ -368,6 +374,8 @@
 - PaperAirplane24
 - Paperclip16
 - Paperclip24
+- PasskeyFill16
+- PasskeyFill24
 - Paste16
 - Paste24
 - Pencil16

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "prepack": "node build"
   },
   "devDependencies": {
-    "@primer/octicons": "18.0.0",
+    "@primer/octicons": "18.2.0",
     "gh-pages": "^4.0.0",
     "svelte": "^3.52.0",
     "svelte-readme": "^3.6.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -63,10 +63,10 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
-"@primer/octicons@18.0.0":
-  version "18.0.0"
-  resolved "https://registry.yarnpkg.com/@primer/octicons/-/octicons-18.0.0.tgz#529426573c921a2f347af4076032f61cb81c6f08"
-  integrity sha512-EC2T95Xl9FCt84pVROjGmwfBvDWxnvWxL+RGsWYNxr1qY7UO58WgLScgi7K8p4gSK5V/k9vHi/k1EhunIyRGRw==
+"@primer/octicons@18.2.0":
+  version "18.2.0"
+  resolved "https://registry.yarnpkg.com/@primer/octicons/-/octicons-18.2.0.tgz#14efe3304536f8e3ef0c5202f9f2fece81708781"
+  integrity sha512-Bx7PkGZUgbo/xbZSdufxKefg5JzvGPkIu/x93TAiWit+FoPBmLammqfHQe1Y5gmT2AWAuxJUksYN05hi7w6VnA==
   dependencies:
     object-assign "^4.1.1"
 


### PR DESCRIPTION
- upgrade `@primer/octicons` to [v18.2.0](https://github.com/primer/octicons/releases/tag/v18.2.0) (net +8 icons)