### PR TITLE
feat(deps): upgrade `@primer/octicons` to 18.3.0

### DIFF
--- a/ICON_INDEX.md
+++ b/ICON_INDEX.md
@@ -1,6 +1,6 @@
 # Icon Index
 
-> 574 total icons
+> 576 total icons
 
 ## Icons
 
@@ -404,6 +404,8 @@
 - ProjectRoadmap24
 - ProjectSymlink16
 - ProjectSymlink24
+- ProjectTemplate16
+- ProjectTemplate24
 - Pulse16
 - Pulse24
 - Question16

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "prepack": "node build"
   },
   "devDependencies": {
-    "@primer/octicons": "18.2.0",
+    "@primer/octicons": "18.3.0",
     "gh-pages": "^4.0.0",
     "svelte": "^3.52.0",
     "svelte-readme": "^3.6.3",

--- a/test/Octicons.test.svelte
+++ b/test/Octicons.test.svelte
@@ -22,6 +22,7 @@
     Goal16,
     SparkleFill16,
     GitMergeQueue24,
+    ProjectTemplate16,
   } from "../lib";
   import Version24 from "../lib/Verified24.svelte";
   import GitPullRequestClosed16 from "../lib/GitPullRequestClosed16.svelte";
@@ -54,6 +55,7 @@
 <Goal16 />
 <SparkleFill16 />
 <GitMergeQueue24 />
+<ProjectTemplate16 />
 
 {#each Object.keys(Octicons) as octicon}
   <div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -63,10 +63,10 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
-"@primer/octicons@18.2.0":
-  version "18.2.0"
-  resolved "https://registry.yarnpkg.com/@primer/octicons/-/octicons-18.2.0.tgz#14efe3304536f8e3ef0c5202f9f2fece81708781"
-  integrity sha512-Bx7PkGZUgbo/xbZSdufxKefg5JzvGPkIu/x93TAiWit+FoPBmLammqfHQe1Y5gmT2AWAuxJUksYN05hi7w6VnA==
+"@primer/octicons@18.3.0":
+  version "18.3.0"
+  resolved "https://registry.yarnpkg.com/@primer/octicons/-/octicons-18.3.0.tgz#49fdcbb59f8b072099512f1635de93cba63d3396"
+  integrity sha512-vyUej5rKjXfqHAmYSo2k3pA9IsL5KJaYOBVXvc188FwBfUweA+WVP3qwWyZTSQnp9LK6yOajGyr0SCMIa9ombw==
   dependencies:
     object-assign "^4.1.1"
 


### PR DESCRIPTION
- upgrade `@primer/octicons` to [v18.3.0](https://github.com/primer/octicons/releases/tag/v18.3.0) (net +2 icons)